### PR TITLE
get latest updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM gliderlabs/alpine
+FROM alpine:latest
 
 # Puppet absolutely needs the shadow utils, such as useradd.
 RUN echo http://dl-4.alpinelinux.org/alpine/edge/testing/ >> /etc/apk/repositories
-RUN apk-install ca-certificates ruby util-linux shadow
-RUN gem install -N facter puppet && rm -fr /root/.gem
-
-# Patch facter to use /etc/os-release on coreos.
-# https://github.com/puppetlabs/facter/pull/866
-ADD https://raw.githubusercontent.com/jumanjiman/facter/coreos_2x/lib/facter/operatingsystem/implementation.rb /usr/lib/ruby/gems/2.1.0/gems/facter-2.4.0/lib/facter/operatingsystem/implementation.rb
-ADD https://raw.githubusercontent.com/jumanjiman/facter/coreos_2x/lib/facter/operatingsystem/osreleaselinux.rb  /usr/lib/ruby/gems/2.1.0/gems/facter-2.4.0/lib/facter/operatingsystem/osreleaselinux.rb
+RUN apk upgrade --update && \
+    apk add \
+      ca-certificates \
+      ruby \
+      util-linux \
+      shadow \
+    && rm -f /var/cache/apk/* && \
+    gem install -N \
+      facter:'>= 2.4.3' \
+      puppet:'< 4.0' \
+    && rm -fr /root/.gem
 
 ENV container docker
 VOLUME ["/sys/fs/cgroup", "/run", "/var/lib/puppet", "/lib64"]


### PR DESCRIPTION
- use official alpine image, which is based on gliderlabs/alpine
- use facter 2.4.3 or higher, which includes my merged patches
- use latest puppet 3.x even though puppet 4.x is now available;
  we don't want to use puppet 4 on client until we upgrade master
