### PR TITLE
use alpine-recommended options to upgrade existing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:latest
 
 # Puppet absolutely needs the shadow utils, such as useradd.
 RUN echo http://dl-4.alpinelinux.org/alpine/edge/testing/ >> /etc/apk/repositories
-RUN apk upgrade --update && \
+RUN apk upgrade --update --available && \
     apk add \
       ca-certificates \
       ruby \


### PR DESCRIPTION
According to http://wiki.alpinelinux.org/wiki/Edge

> The `--available` switch is used to force all packages to be upgraded,
> even if they have the same version numbers.
> Sometimes changes in uClibc have required doing this.
