### PR TITLE
upgrade openssl to resolve CVE-2015-1793

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN echo http://dl-4.alpinelinux.org/alpine/edge/testing/ >> /etc/apk/repositori
 RUN apk upgrade --update --available && \
     apk add \
       ca-certificates \
+      openssl=1.0.1p-r0 \
       ruby \
       util-linux \
       shadow \


### PR DESCRIPTION
Before this commit, we simply install latest version
of openssl as a dependency of ca-certificates.

After this commit, pin openssl to make it clear which
version is installed.
