### PR TITLE
use full-feature lspci instead of busybox lspci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk upgrade --update --available && \
       && \
     apk add \
       ca-certificates \
+      pciutils \
       'ruby<2.2' \
       util-linux \
       shadow \


### PR DESCRIPTION
This is the version from http://mj.ucw.cz/pciutils.html
that also includes PCI ID's packaged for Alpine at
https://pkgs.alpinelinux.org/package/v3.4/main/x86_64/pciutils

This is useful to get useful info from hardware facter facts
because the busybox version of lspci is pretty bare.
